### PR TITLE
Better spritesheet hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - "0.12"
   - "0.11"
-  - "0.10"
   - "4.0.0"
   - "stable"

--- a/lib/spritesheet.js
+++ b/lib/spritesheet.js
@@ -84,7 +84,11 @@ module.exports = function Spritesheet(name, scaledSprites, groupConfig, config, 
     }
 
     that.process = function() {
-        return cache.lookup("spritesheet", name, cacheMiss, 3)
+        var hash = name + "_" +
+            that.extension + "_" +
+            (groupConfig.quality ? groupConfig.quality : "noquality") + "_" +
+            (groupConfig.compression ? groupConfig.compression : "nocompression");
+        return cache.lookup("spritesheet", hash, cacheMiss, 3)
         .then(cacheInterpret)
         .then(function() { return that; });
     };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "pretest": "eslint lib test example.js",
     "test": "mocha --recursive test"
   },
+  "engines" : { "node" : ">=0.11.0" },
   "main": "index.js",
   "repository": "gamevy/pixi-packer",
   "bin": "./cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-packer",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A quick and flexible texture packer for PIXI.js",
   "scripts": {
     "pretest": "eslint lib test example.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi-packer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A quick and flexible texture packer for PIXI.js",
   "scripts": {
     "pretest": "eslint lib test example.js",

--- a/test/unit/full.js
+++ b/test/unit/full.js
@@ -28,7 +28,7 @@ describe("Full run", function () {
 
             pixiPacker = new PixiPacker(
                 config,
-                path.resolve(__dirname, ".."),
+                path.resolve(__dirname, "../.."),
                 path.resolve(__dirname, outputPath),
                 path.resolve(__dirname, tempPath)
             );
@@ -60,12 +60,13 @@ describe("Full run", function () {
     });
 
     it("has the right resolution", function() {
-        var manifest = require(outputPath + "/game_DE_web_retina.json");
+        var manifest = JSON.parse(fs.readFileSync(outputPath + "/game_DE_web_retina.json", "utf8"));
         assert.equal(manifest.resolution, 2);
     });
 
     it("creates all images", function() {
-        var manifest = require(outputPath + "/game_DE_web_retina.json");
+        var manifest = JSON.parse(fs.readFileSync(outputPath + "/game_DE_web_retina.json", "utf8"));
+        assert.ok(manifest.spritesheets.length > 0);
         manifest.spritesheets.forEach(function(spritesheet) {
             assert.ok(fs.lstatSync(outputPath + "/" + spritesheet.image).isFile());
         });


### PR DESCRIPTION
This fixes a problem where picking a new compression or switching between jpeg/png did not invalidate the cache for already processed spritesheets. 

The tests have been broken already and I haven't realised it until now. Bad Marek, bad!