### PR TITLE
Better error message for duplicated spritenames

### DIFF
--- a/lib/loading_manifest.js
+++ b/lib/loading_manifest.js
@@ -39,6 +39,7 @@ module.exports = function LoadingManifest(groups, scaleName, scaleResolution, va
         var totalSize = 0;
         var totalFiles = 0;
         var names = {};
+        var nameToGroup = {};
 
         manifestRaw.spritesheets = _.flatten(_.map(getScaledGroups(), function(scaledGroup) {
             _.each(scaledGroup.spritesheets, function(spritesheet) {
@@ -48,9 +49,12 @@ module.exports = function LoadingManifest(groups, scaleName, scaleResolution, va
 
             return _.map(scaledGroup.spritesheets, function(spritesheet) {
                 _.each(spritesheet.loadingInformation, function(sprite) {
-                    if (names[sprite.name]) {
-                        throw new Error("Sprite " + sprite.name + " exists twice");
+
+                    if (nameToGroup[sprite.name]) {
+                        throw new Error("Sprite " + sprite.name + " exists twice in manifest " + scaleName + ". " +
+                            "Contained groups: " + scaledGroup.groupId + ", " + nameToGroup[sprite.name]);
                     }
+                    nameToGroup[sprite.name] = scaledGroup.groupId;
                     names[sprite.name] = true;
                 });
 

--- a/lib/pixi_packer.js
+++ b/lib/pixi_packer.js
@@ -67,6 +67,11 @@ module.exports = function PixiPacker(config, inputPath, outputPath, cachePath) {
         .then(createCache)
         .then(function(cache) {
             return createAndProcessGroups(cache)
+            .then(function(groups) {
+                // Save in case error occurs during createAndSaveLoadingManifests step
+                cache.save();
+                return groups;
+            })
             .then(createAndSaveLoadingManifests)
             .then(cache.save);
         })

--- a/lib/scaled_group.js
+++ b/lib/scaled_group.js
@@ -7,6 +7,7 @@ var Spritesheet = require("./spritesheet");
 module.exports = function ScaledGroup(scaledSprites, groupHash, scaleName, groupConfig, config, cache, cachePath, imageProcessor) {
     var that = this;
     that.scaleName = scaleName;
+    that.groupId = groupConfig.id;
     that.spritesheets = [];
 
     function createAndProcessSpritesheets() {


### PR DESCRIPTION
The ```Sprite xyz exists twice``` error was difficult to debug, this should make it slightly easier.