### PR TITLE
Attempt to fix error caused by same sprite found in two spritesheets

### DIFF
--- a/lib/loading_manifest.js
+++ b/lib/loading_manifest.js
@@ -59,7 +59,7 @@ module.exports = function LoadingManifest(groups, scaleName, scaleResolution, va
                 });
 
                 return {
-                    image: spritesheet.basename,
+                    image: spritesheet.getBasename(),
                     filesize: spritesheet.outputFilesize,
                     sprites: spritesheet.loadingInformation
                 };

--- a/lib/spritesheet.js
+++ b/lib/spritesheet.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var crypto = require("crypto");
 var fs = require("fs-extra");
 var Q = require("q");
 var _ = require("underscore");
@@ -83,11 +84,17 @@ module.exports = function Spritesheet(name, scaledSprites, groupConfig, config, 
         that.outputFilesize = data.outputFilesize;
     }
 
+     function calculateHash() {
+        var hash = crypto.createHash("sha1");
+        hash.update(_.pluck(scaledSprites, "path").sort().join(" ") + "_");
+        hash.update(that.extension + "_");
+        hash.update((groupConfig.quality ? groupConfig.quality : "noquality") + "_");
+        hash.update((groupConfig.compression ? groupConfig.compression : "nocompression"));
+        return name + "_" + hash.digest("hex");
+    }
+
     that.process = function() {
-        var hash = name + "_" +
-            that.extension + "_" +
-            (groupConfig.quality ? groupConfig.quality : "noquality") + "_" +
-            (groupConfig.compression ? groupConfig.compression : "nocompression");
+        var hash = calculateHash();
         return cache.lookup("spritesheet", hash, cacheMiss, 3)
         .then(cacheInterpret)
         .then(function() { return that; });

--- a/lib/spritesheet.js
+++ b/lib/spritesheet.js
@@ -8,11 +8,13 @@ var path = require("path");
 
 module.exports = function Spritesheet(name, scaledSprites, groupConfig, config, cache, cachePath, imageProcessor) {
     var that = this;
-    that.extension = groupConfig.jpeg ? "jpeg" : "png";
-    that.basename = name + "." + that.extension;
+
+    function getExtension() {
+        return groupConfig.jpeg ? "jpeg" : "png";
+    }
 
     function copyFiles(outputPath) {
-        var outputImagePath = outputPath + "/" + name + "." + that.extension;
+        var outputImagePath = outputPath + "/" + name + "." + getExtension();
         return Q.nfcall(fs.copy, that.cachedImagePath, outputImagePath);
     }
 
@@ -64,7 +66,7 @@ module.exports = function Spritesheet(name, scaledSprites, groupConfig, config, 
     }
 
     function cacheMiss() {
-        var cachedImagePath = cachePath + "/" + that.basename;
+        var cachedImagePath = cachePath + "/" + that.getBasename();
         return createImage(cachedImagePath)
         .then(function(result) {
             return createLoadingInformation(cachedImagePath, result);
@@ -84,17 +86,21 @@ module.exports = function Spritesheet(name, scaledSprites, groupConfig, config, 
         that.outputFilesize = data.outputFilesize;
     }
 
-     function calculateHash() {
+    that.getBasename = function () {
+        return name + "." + getExtension();
+    };
+
+    that.calculateHash = function () {
         var hash = crypto.createHash("sha1");
         hash.update(_.pluck(scaledSprites, "path").sort().join(" ") + "_");
-        hash.update(that.extension + "_");
+        hash.update(getExtension() + "_");
         hash.update((groupConfig.quality ? groupConfig.quality : "noquality") + "_");
         hash.update((groupConfig.compression ? groupConfig.compression : "nocompression"));
         return name + "_" + hash.digest("hex");
-    }
+    };
 
     that.process = function() {
-        var hash = calculateHash();
+        var hash = that.calculateHash();
         return cache.lookup("spritesheet", hash, cacheMiss, 3)
         .then(cacheInterpret)
         .then(function() { return that; });

--- a/test/unit/spritesheet.js
+++ b/test/unit/spritesheet.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var Spritesheet = require("../../lib/spritesheet");
+var assert = require("chai").assert;
+
+describe("Spritesheet", function () {
+    var spritesheet, scaledSprites, groupConfig, config, cache, cachePath, imageProcessor;
+
+    beforeEach(function() {
+        scaledSprites = [
+            {"path": "/one/sprite"},
+            {"path": "/another/sprite"}
+        ];
+        groupConfig = {
+            jpeg: true,
+            quality: 90,
+            compression: "pngquant"
+        };
+        config = {};
+        cache = {};
+        cachePath = "/some/path";
+        imageProcessor = {};
+        spritesheet = new Spritesheet("test-spritesheet", scaledSprites, groupConfig, config, cache, cachePath, imageProcessor);
+    });
+
+    context("#calculateHash", function() {
+        var originalHash;
+        beforeEach(function() {
+            originalHash = spritesheet.calculateHash();
+        });
+
+        it("stays the same if no change is made", function() {
+            var otherSpritesheet = new Spritesheet("test-spritesheet", scaledSprites, groupConfig, config, cache, cachePath, imageProcessor);
+            assert.equal(originalHash, otherSpritesheet.calculateHash());
+        });
+
+        it("changes when scaledSprites changes", function() {
+            scaledSprites[0].path = "/one/sprite/changed";
+            assert.notEqual(originalHash, spritesheet.calculateHash());
+        });
+
+        it("changes when scaledSprites is added", function() {
+            scaledSprites.push({"path": "/yet/another/one"});
+            assert.notEqual(originalHash, spritesheet.calculateHash());
+        });
+
+        it("changes when extension changes", function() {
+            groupConfig.jpeg = false;
+            assert.notEqual(originalHash, spritesheet.calculateHash());
+        });
+
+        it("changes when quality changes", function() {
+            groupConfig.quality = 75;
+            assert.notEqual(originalHash, spritesheet.calculateHash());
+        });
+
+        it("changes when compression changes", function() {
+            groupConfig.compression = "optipng";
+            assert.notEqual(originalHash, spritesheet.calculateHash());
+        });
+    });
+
+    it("has the correct basename", function() {
+        assert.equal(spritesheet.getBasename(), "test-spritesheet.jpeg");
+    });
+});


### PR DESCRIPTION
```
Error: Sprite word_option_button_00018 exists twice in manifest web_retina. Contained groups: game, game
```

My current theory as to why this is happening is that due to some file system shenigans the order of sprites processed has changed. Since the group hash is based on a sorted list of sprites this will mean the group hash stays the same. It might however change which sprites gets put into which spritesheet, potentially leading to a case where only some spritesheets get reprossesed and certain sprites now being found in two spritesheets.

This fix adds the whole set of sprite paths to the spritesheet hash invalidating them when the collection of sprites on that sheet changes.

Disclaimer: I have so far not been able to replicate this locally, so this fix is an educated guess.

This will change the hash key for all spritesheets, so expect longer build times for the one build after the update.