### PR TITLE
Update "image-size" to version ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "glob": "^6.0.1",
     "gm": "^1.21.1",
     "gmsmith": "^0.6.4",
-    "image-size": "^0.3.5",
+    "image-size": "^0.4.0",
     "mkdirp": "^0.5.1",
     "optipng-bin": "~2.0.4",
     "pngquant-bin": "~3.0.0",


### PR DESCRIPTION
0.4.0 / 2015-11-23
==================

  * 0.4.0
  * Add NPM version badge
    from https://shields.io/
  * Merge pull request [#50](https://github.com/image-size/image-size/issues/50) from vampirical/patch-1
    Support all JPGs rather than specific JFIF ones
  * Merge pull request [#36](https://github.com/image-size/image-size/issues/36) from borodean/master
    Support SVG with only viewbox specified
  * test for percentages ignored
  * refactor SVG calculation
  * allow single-quoted SVGs
  * Expose supported file types
    fix GH-42
    close GH-43
  * Use `files` field instead of .npmignore
  * Add .js extension to the CLI file name
  * remove unneeded TEST_COV branching
    We don’t use jscoverage any more.
  * Add the project title to the top of readme
  * Merge pull request [#60](https://github.com/image-size/image-size/issues/60) from image-size/no-make
    Use npm scripts instead of Makefile
  * Merge pull request [#57](https://github.com/image-size/image-size/issues/57) from zeke/document-cli
    Document the CLI
  * Use npm scripts instead of Makefile
    Because it’s more familiar to Node developers.
  * Merge pull request [#59](https://github.com/image-size/image-size/issues/59) from image-size/badge-url
    Update badge URLs
  * Update badge URLs
    The repo has been transferred.
  * Update devDependencies
  * Test on the latest stable Node
  * Merge pull request [#53](https://github.com/image-size/image-size/issues/53) from LinusU/patch-1
    correct check for buffer
  * add CLI installation and usage to readme
  * fix typo
  * correct check for buffer
    There are some cases where `instanceof Buffer` won't work, this fixes that by using the builtin `Buffer.isBuffer` instead.
  * Support all JPGs rather than specific JFIF ones
    For the purposes of this library requiring JPEGs use the JFIF standard doesn't seem necessary. Old school non-JFIF jpegs, like the kind produced by ffmpeg, aren't usable as-is.
    Since there was only a limited set of markers in the list and a TODO to support all I've just removed the JFIF requirement entirely. JFIF will still work fine but now so will all valid JPEGs.
  * reuse getViewboxSize for getRatio function
  * support SVG with viewbox only
  * Update Readme.md