### PR TITLE
Update "spritesmith" to version ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
     "gm": "^1.21.1",
-    "gmsmith": "^0.6.4",
+    "gmsmith": "^1.0.0",
     "image-size": "^0.3.5",
     "mkdirp": "^0.5.1",
     "optipng-bin": "~2.0.4",
@@ -35,7 +35,7 @@
     "qlimit": "^0.1.1",
     "rimraf": "^2.4.1",
     "sinon-chai": "^2.8.0",
-    "spritesmith": "^1.5.0",
+    "spritesmith": "^3.0.0",
     "underscore": "^1.8.3",
     "yargs": "^3.29.0"
   },


### PR DESCRIPTION
3.0.0 / 2015-11-22
==================

  * Release 3.0.0
  * Added new image
  * Cleaned up TODO
  * Updated examples in README
  * Updated examples and caught errors
  * Added new example
  * Documented breaking changes
  * Relocated Spritesmith.run as first function
  * Completed updating documentation
  * Documented Spritesmith.run
  * Starting on updating documentation
  * Removed old breaking changes
  * Moved from img to image for legacy preservation
  * Updated misses one-offs
  * Pulling back old tests
  * Coming full circle on API
  * Content with new middleground for run
  * Updated tests to interact with info object
  * Got back some sanity by laying out images sync and outside of a stream
  * Fixed up a one-off and lint error
  * Updated test to use class
  * Completed transition from one function to class
  * Handling sugar function
  * Broke down spritesmith into image creation and processing
  * Updated TODO
  * Fixed up failing edge case
  * Completed empty array support
  * Repairing empty array handling
  * Fixed up more one-offs
  * Fixed up one-offs in tests
  * Fixed up img double callback as well
  * Fixed up double callbacks
  * Added missing dependency
  * Updated test suite to handle streams
  * Completed stream support
  * Added support for streams interface
  * Updated tests to use new run syntax
  * Completed gist of content
  * Exploring API for stream returning spritesmith

2.0.1 / 2015-11-18
==================

  * Release 2.0.1
  * Updated donation URL

2.0.0 / 2015-11-18
==================

  * Release 2.0.0
  * Upgraded pixelsmith, canvassmith, and phantomjssmith to their spritesmith-engine-spec@2.0.0 equivalents
  * Made upgrade example more generic
  * Added instructions for users on engine upgrade
  * Documented breaking changes in 2.0.0
  * Removed git+ssh URLs to guarantee Travis CI fails until we use new semvers
  * Documented vinyl support
  * Fixed up backwards compatibility with older Vinyl setups
  * Updated dependencies
  * Added test for vinyl support
  * Added vinyl support
  * Updated documentation to use buffer over binary string
  * Replaced annoyance of '' with null
  * Updated handling of empty images
  * Moved to returning a buffer over binary string but not a stream for now
  * Removed excessive wrapper CanvasSmith
  * Moved to full GitHub URLs
  * Fixed up version issues
  * Removed excess wrapper EngineSmith
  * Updated specification version in README
  * Fixed up one-off logic
  * Updated canvas creation
  * Simplified canvas.smith
  * Replaced EngineSmith legacy with Engine constructor
  * Moved to new spec version