### PR TITLE
Update "eslint" to version ^1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^1.9.2",
-    "eslint": "^0.20.0",
+    "eslint": "^1.10.3",
     "mocha": "~2.2.1",
     "sinon": "~1.14.1",
     "sinon-chai": "~2.7.0"


### PR DESCRIPTION
2.0.0-alpha-1 / 2015-12-11
==========================

  * Merge pull request [#4675](https://github.com/eslint/eslint/issues/4675) from eslint/pr4648
    Breaking: Correct links between variables and references (fixes [#4615](https://github.com/eslint/eslint/issues/4615))
  * Breaking: Correct links between variables and references (fixes [#4615](https://github.com/eslint/eslint/issues/4615))
  * Merge pull request [#4674](https://github.com/eslint/eslint/issues/4674) from eslint/issue4673
    Fix: Update rule tests for parser options (fixes [#4673](https://github.com/eslint/eslint/issues/4673))
  * Fix: Update rule tests for parser options (fixes [#4673](https://github.com/eslint/eslint/issues/4673))
  * Merge pull request [#4628](https://github.com/eslint/eslint/issues/4628) from mysticatea/array-callback-return/new
    New: `array-callback-return` rule
  * Merge pull request [#4565](https://github.com/eslint/eslint/issues/4565) from josh/issue4542
    New: Add no-implicit-globals rule (fixes [#4542](https://github.com/eslint/eslint/issues/4542))
  * Merge pull request [#4670](https://github.com/eslint/eslint/issues/4670) from nre/issue4661
    Fix: max-len rule overestimates the width of some tabs (fixes [#4661](https://github.com/eslint/eslint/issues/4661))
  * Merge pull request [#4664](https://github.com/eslint/eslint/issues/4664) from eslint/issue4641
    Breaking: Implement parserOptions (fixes [#4641](https://github.com/eslint/eslint/issues/4641))
  * Breaking: Implement parserOptions (fixes [#4641](https://github.com/eslint/eslint/issues/4641))
  * Fix: max-len rule overestimates the width of some tabs (fixes [#4661](https://github.com/eslint/eslint/issues/4661))
    max-len incorrectly assumed that all tab characters were the same width
    as the tab stops.
  * New: Add no-implicit-globals rule (fixes [#4542](https://github.com/eslint/eslint/issues/4542))
  * Merge pull request [#4650](https://github.com/eslint/eslint/issues/4650) from mysticatea/no-use-before-define/invalid-initializer
    Update: `no-use-before-define` checks invalid initializer
  * Update: `no-use-before-define` checks invalid initializer (fixes [#4280](https://github.com/eslint/eslint/issues/4280))
  * Merge pull request [#4647](https://github.com/eslint/eslint/issues/4647) from gkz/issue4507
    Fix: Use oneValuePerFlag for --ignore-pattern option (fixes [#4507](https://github.com/eslint/eslint/issues/4507))
  * Fix: Use oneValuePerFlag for --ignore-pattern option (fixes [#4507](https://github.com/eslint/eslint/issues/4507))
    Updates optionator from 0.6.0 to 0.7.1
    Multiple ignore patterns must be specified by using the flag multiple
    times, not by using a comma (since the pattern could include a comma)
  * New: `array-callback-return` rule (fixes [#1128](https://github.com/eslint/eslint/issues/1128))
  * Merge pull request [#4644](https://github.com/eslint/eslint/issues/4644) from betaorbust/issue4642
    Upgrade: Handlebars to >= 4.0.5 for security reasons (fixes [#4642](https://github.com/eslint/eslint/issues/4642))
  * Upgrade: Handlebars to >= 4.0.5 for security reasons (fixes [#4642](https://github.com/eslint/eslint/issues/4642))
    NSP has a reported security vulnerability with old versions of uglify, which is used by handlebars < 4.0.5.
    https://nodesecurity.io/advisories/48
    This update changes eslint's minimum handlebars version up from 4.0.0 to 4.0.5.
  * Merge pull request [#4639](https://github.com/eslint/eslint/issues/4639) from eslint/issue4372
    Update: Add class body support to `indent` rule (fixes [#4372](https://github.com/eslint/eslint/issues/4372))
  * Update: Add class body support to `indent` rule (fixes [#4372](https://github.com/eslint/eslint/issues/4372))
  * Merge pull request [#4173](https://github.com/eslint/eslint/issues/4173) from eslint/issue4149
    Fix: space-after-keyword newline check (fixes [#4149](https://github.com/eslint/eslint/issues/4149))
  * Breaking: Remove space-after-keyword newline check (fixes [#4149](https://github.com/eslint/eslint/issues/4149))
  * Merge pull request [#4597](https://github.com/eslint/eslint/issues/4597) from mysticatea/no-use-before-define/noclass
    Update: add class option to `no-use-before-define`
  * Merge pull request [#4617](https://github.com/eslint/eslint/issues/4617) from kaicataldo/fixes4605
    Update: Add 'method' option to no-empty (fixes [#4605](https://github.com/eslint/eslint/issues/4605))
  * Merge pull request [#4624](https://github.com/eslint/eslint/issues/4624) from eslint/issue-4451
    Breaking: Treat package.json like the rest of configs (fixes [#4451](https://github.com/eslint/eslint/issues/4451))
  * Breaking: Treat package.json like the rest of configs (fixes [#4451](https://github.com/eslint/eslint/issues/4451))
  * Merge pull request [#4574](https://github.com/eslint/eslint/issues/4574) from kaicataldo/objectshorthandignoreconstructors
    Update: Add option to ignore constructor functions in object-shorthand rule (fixes [#4487](https://github.com/eslint/eslint/issues/4487))
  * Merge pull request [#4547](https://github.com/eslint/eslint/issues/4547) from platinumazure/ignore-pattern-array-tests
    Fix: Adding options unit tests for --ignore-pattern (refs [#4507](https://github.com/eslint/eslint/issues/4507))
  * Merge pull request [#4614](https://github.com/eslint/eslint/issues/4614) from eslint/issue-4578
    Breaking: Remove autofix from eqeqeq (fixes [#4578](https://github.com/eslint/eslint/issues/4578))
  * Merge pull request [#4629](https://github.com/eslint/eslint/issues/4629) from molee1905/master
    Docs: writing mistake
  * Docs: writing mistake
  * Merge pull request [#4621](https://github.com/eslint/eslint/issues/4621) from eslint/issue4085
    Breaking: Remove ES6 global variables from builtins (fixes [#4085](https://github.com/eslint/eslint/issues/4085))
  * Update: Add 'method' option to no-empty (fixes [#4605](https://github.com/eslint/eslint/issues/4605))
  * Breaking: Remove autofix from eqeqeq (fixes [#4578](https://github.com/eslint/eslint/issues/4578))
  * Merge pull request [#4253](https://github.com/eslint/eslint/issues/4253) from mysticatea/no-unreachable/code-path-analysis
    Fix: `no-unreachable` with the code path
  * Merge pull request [#4252](https://github.com/eslint/eslint/issues/4252) from mysticatea/no-this-before-super/code-path-analysis
    Fix: `no-this-before-super` with the code path analysis
  * Merge pull request [#4251](https://github.com/eslint/eslint/issues/4251) from mysticatea/no-fallthrough/code-path-analysis
    Fix: `no-fallthrough` with the code path analysis
  * Merge pull request [#4249](https://github.com/eslint/eslint/issues/4249) from mysticatea/constructor-super/code-path-analysis
    Fix: `constructor-super` with the code path analysis
  * Merge pull request [#4612](https://github.com/eslint/eslint/issues/4612) from eslint/issue4229
    Fix: Handle forbidden LineTerminators in no-extra-parens (fixes [#4229](https://github.com/eslint/eslint/issues/4229))
  * Breaking: Remove ES6 global variables from builtins (fixes [#4085](https://github.com/eslint/eslint/issues/4085))
    This upgrades to `globals@8.14.0`, which has separate `es5` and `es6`
    environments. Only ES5 global variables are considered builtin now, and
    ES6 global variables are supplied as part of the `es6` environment.
  * Fix: Handle forbidden LineTerminators in no-extra-parens (fixes [#4229](https://github.com/eslint/eslint/issues/4229))
    Previously, this rule would warn about excess parentheses even when they
    were syntactically significant and removing them would alter the meaning
    of a program. There are three applicable productions in the grammar with
    the restriction `[no LineTerminator here]`:
    ```
    ReturnStatement[Yield]:
    return [no LineTerminator here] Expression;
    return [no LineTerminator here] Expression[In, ?Yield];
    ThrowStatement[Yield]:
    throw [no LineTerminator here] Expression[In, ?Yield];
    YieldExpression[In]:
    yield [no LineTerminator here] * AssignmentExpression[?In, Yield]
    yield [no LineTerminator here] AssignmentExpression[?In, Yield]
    ```
    If the expression following a `return`, `throw`, or `yield` is on a new
    line, it must be wrapped in parentheses, and this rule should not warn.
    It should, however, still check for double parentheses, since the second
    set would be unnecessary.
    Thanks to @michaelficarra for pasting the relevant portions of the spec.
  * Update: Option to ignore constructor Fns object-shorthand (fixes [#4487](https://github.com/eslint/eslint/issues/4487))
  * Merge pull request [#4610](https://github.com/eslint/eslint/issues/4610) from SpainTrain/dont-module-cache-package-json
    Do not implicitly cache `package.json`
  * Merge pull request [#4609](https://github.com/eslint/eslint/issues/4609) from eslint/issue4608
    Fix: Check YieldExpression argument in no-extra-parens (fixes [#4608](https://github.com/eslint/eslint/issues/4608))
  * Fix: Check YieldExpression argument in no-extra-parens (fixes [#4608](https://github.com/eslint/eslint/issues/4608))
  * Fix: Do not cache `package.json` (fixes [#4611](https://github.com/eslint/eslint/issues/4611))
    * Read `package.json` on every config load by not using `require`
  * Merge pull request [#4590](https://github.com/eslint/eslint/issues/4590) from guyellis/no-restricted-imports
    New: Add no-restricted-imports rule (fixes [#3196](https://github.com/eslint/eslint/issues/3196))
  * Merge pull request [#4604](https://github.com/eslint/eslint/issues/4604) from platinumazure/dogfood-no-underscore-dangle
    Build: Consume no-underscore-dangle allowAfterThis option (fixes [#4599](https://github.com/eslint/eslint/issues/4599))
  * Build: Consume no-underscore-dangle allowAfterThis option (fixes [#4599](https://github.com/eslint/eslint/issues/4599))
  * New: Add no-restricted-imports rule (fixes [#3196](https://github.com/eslint/eslint/issues/3196))
  * Merge pull request [#4596](https://github.com/eslint/eslint/issues/4596) from eslint/issue3625
    Breaking: Simplify rule schemas (fixes [#3625](https://github.com/eslint/eslint/issues/3625))
  * Merge pull request [#4601](https://github.com/eslint/eslint/issues/4601) from platinumazure/no-extra-semi-link-fix
    Docs: no-extra-semi no longer refers to deprecated rule (fixes [#4598](https://github.com/eslint/eslint/issues/4598))
  * Docs: no-extra-semi no longer refers to deprecated rule (fixes [#4598](https://github.com/eslint/eslint/issues/4598))
  * Merge pull request [#4586](https://github.com/eslint/eslint/issues/4586) from eslint/issue3095
    Docs: Add Code of Conduct (fixes [#3095](https://github.com/eslint/eslint/issues/3095))
  * Merge pull request [#4248](https://github.com/eslint/eslint/issues/4248) from mysticatea/consistent-return/code-path-analysis
    Fix: `consistent-return` comes to checking the last path.
  * Fix: `consistent-return` checks the last (refs [#3530](https://github.com/eslint/eslint/issues/3530), fixes [#3373](https://github.com/eslint/eslint/issues/3373))
  * Update: add class option to `no-use-before-define` (fixes [#3944](https://github.com/eslint/eslint/issues/3944))
  * Breaking: Simplify rule schemas (fixes [#3625](https://github.com/eslint/eslint/issues/3625))
  * Merge pull request [#4335](https://github.com/eslint/eslint/issues/4335) from eslint/issue4334
    Breaking: Switch to Espree 3.0.0 (fixes [#4334](https://github.com/eslint/eslint/issues/4334))
  * Merge pull request [#4592](https://github.com/eslint/eslint/issues/4592) from JulianLaval/issue3550
    Breaking: added bower_components to default ignore (fixes [#3550](https://github.com/eslint/eslint/issues/3550))
  * Merge pull request [#4594](https://github.com/eslint/eslint/issues/4594) from yjcxy12/patch-1
    Docs: Update docs/rules/no-plusplus.md
  * Merge pull request [#4566](https://github.com/eslint/eslint/issues/4566) from mysticatea/no-undef/remove-notification-of-readonly
    Breaking: Remove warnings of readonly from `no-undef`
  * Docs: Update docs/rules/no-plusplus.md
    Used correct format when using options
  * Breaking: added bower_components to default ignore (fixes [#3550](https://github.com/eslint/eslint/issues/3550))
  * Fix: `no-unreachable` with the code path (refs [#3530](https://github.com/eslint/eslint/issues/3530), fixes [#3939](https://github.com/eslint/eslint/issues/3939))
  * Fix: `no-this-before-super` with the code path analysis (refs [#3530](https://github.com/eslint/eslint/issues/3530))
  * Fix: `no-fallthrough` with the code path analysis (refs [#3530](https://github.com/eslint/eslint/issues/3530))
  * Fix: `constructor-super` with the code path analysis (refs [#3530](https://github.com/eslint/eslint/issues/3530))
  * Merge pull request [#3559](https://github.com/eslint/eslint/issues/3559) from mysticatea/code-path-analysis/new
    New: code path analysis.
  * Breaking: Switch to Espree 3.0.0 (fixes [#4334](https://github.com/eslint/eslint/issues/4334))
  * Merge pull request [#4588](https://github.com/eslint/eslint/issues/4588) from eslint/issue4495
    Breaking: Freeze context object (fixes [#4495](https://github.com/eslint/eslint/issues/4495))
  * Breaking: Freeze context object (fixes [#4495](https://github.com/eslint/eslint/issues/4495))
    This reverts commit bec6c9b0e2edca5f5bc99a7abc13b6f62a9a5411.
  * Merge pull request [#4502](https://github.com/eslint/eslint/issues/4502) from eslint/issue4193
    Breaking: Default no-magic-numbers to none. (fixes [#4193](https://github.com/eslint/eslint/issues/4193))
  * Merge pull request [#4524](https://github.com/eslint/eslint/issues/4524) from mysticatea/prefer-rest-params/new
    New: `prefer-rest-params` rule
  * Merge pull request [#4562](https://github.com/eslint/eslint/issues/4562) from just-boris/issue3435
    Add option to allow dangling underscores after `this`
  * Merge pull request [#4453](https://github.com/eslint/eslint/issues/4453) from eslint/issue4411
    Breaking: Allow empty arrow body (fixes [#4411](https://github.com/eslint/eslint/issues/4411))
  * Merge pull request [#4486](https://github.com/eslint/eslint/issues/4486) from bryanrsmith/issue-4115
    Breaking: Implement yield-star-spacing rule (fixes [#4115](https://github.com/eslint/eslint/issues/4115))
  * Merge pull request [#4522](https://github.com/eslint/eslint/issues/4522) from mysticatea/prefer-const/support-separating-init
    Update: `prefer-const` begins to cover separating init
  * Merge pull request [#4505](https://github.com/eslint/eslint/issues/4505) from mysticatea/no-eval/detect-indirect-eval
    Fix: `no-eval` come to catch indirect eval
  * 1.10.3

1.10.3 / 2015-12-01
===================

  * Merge pull request [#4584](https://github.com/eslint/eslint/issues/4584) from eslint/issue4583
    Docs: Update strict rule docs (fixes [#4583](https://github.com/eslint/eslint/issues/4583))
  * Docs: Add Code of Conduct (fixes [#3095](https://github.com/eslint/eslint/issues/3095))
  * Docs: Update strict rule docs (fixes [#4583](https://github.com/eslint/eslint/issues/4583))
  * Merge pull request [#4577](https://github.com/eslint/eslint/issues/4577) from kaicataldo/configurationfilesdocs
    Docs: Reference .eslintrc.* in contributing docs (fixes [#4532](https://github.com/eslint/eslint/issues/4532))
  * Merge pull request [#4573](https://github.com/eslint/eslint/issues/4573) from kaicataldo/curlyforof
    Fix: Add for-of to `curly` rule (fixes [#4571](https://github.com/eslint/eslint/issues/4571))