### PR TITLE
Update "mocha" to version ~2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "eslint": "^1.10.3",
-    "mocha": "~2.2.1",
+    "mocha": "~2.3.4",
     "sinon": "~1.17.2",
     "sinon-chai": "~2.8.0"
   },


### PR DESCRIPTION
2.3.4 / 2015-11-15
==================

  * Merge pull request [#1954](https://github.com/mochajs/mocha/issues/1954) from joeycozza/master
    Update debug dependency to 2.2.0
  * Update debug dependency to 2.2.0
    debug@2.0.0 has a vulnerability in its dependency on ms@0.6.2.
    debug@2.2.0 has updated its ms dependency to a version without this vulnerability.
  * Merge pull request [#1910](https://github.com/mochajs/mocha/issues/1910) from nexdrew/fix/mocha-opts-dupe
    Fix duplication of mocha.opts on process.argv
  * remove duplication of mocha.opts on process.argv
  * Merge pull request [#1909](https://github.com/mochajs/mocha/issues/1909) from berkerpeksag/patch-1
    Fix typo in test/reporters/nyan.js
  * Fix typo in test/reporters/nyan.js
    peinding -> pending

2.3.3 / 2015-09-21
==================

  * rebuild mocha.js for 2.3.3
  * bump package.json and component.json to 2.3.3
  * Fix node 0.8 blowing up upgrading npm 1 -> 3
    Relevant: https://github.com/npm/npm/issues/9668
  * Update HISTORY.md for 2.3.3
  * Remove trailing whitespace from HISTORY.md
  * Merge pull request [#1889](https://github.com/mochajs/mocha/issues/1889) from danielstjules/issue-1798
    Fix [#1798](https://github.com/mochajs/mocha/issues/1798): Correctly attribute mutiple done err with hooks
  * Fix [#1798](https://github.com/mochajs/mocha/issues/1798): Correctly attribute mutiple done err with hooks
  * Merge pull request [#1880](https://github.com/mochajs/mocha/issues/1880) from danielstjules/stackfilter-browser
    Stackfilter fix: Don't remove modules/components from stack trace in the browser
  * Merge pull request [#1888](https://github.com/mochajs/mocha/issues/1888) from danielstjules/revert-jade
    Revert jade to support npm < v1.3.7
  * Merge pull request [#1886](https://github.com/mochajs/mocha/issues/1886) from danielstjules/uncaught-delay
    Fix [#1669](https://github.com/mochajs/mocha/issues/1669): catch uncaught errors outside test suite execution
  * Remove redundant harmony flag
  * Cast non-string return values from err.inspect()
  * Call the inspect() function if message is not set
    Unfortunately some frameworks throw error objects which do not have a `message`
    property but do have an `inspect()` function. This means Mocha reports a test
    failure, but prints the empty string instead of any useful information about
    the error message. For an example, see versions of the Waterline ORM before
    v0.10.19: https://github.com/balderdashy/waterline/commit/0965d132
    If the `message` key is not set on an error object, attempt to print the same
    output as `console.log` in Node, by calling the object's `inspect()` function,
    if it exists.
    We could try to fallback to calling `util.inspect` on the `err` object and
    logging that, but I'm not sure the format would be appropriate.
  * Revert jade to support npm < v1.3.7
  * Fix eqeqeq linting errors from eslint 1.4.0 release
  * Fix [#1669](https://github.com/mochajs/mocha/issues/1669): catch uncaught errors outside test suite execution
  * Merge pull request [#1882](https://github.com/mochajs/mocha/issues/1882) from danielstjules/fragile
    Fix fragile xunit reporter spec
  * Merge pull request [#1885](https://github.com/mochajs/mocha/issues/1885) from danielstjules/flags
    Support all harmony flags
  * Support all harmony flags
  * Fix fragile xunit reporter spec
  * Fix linter warning
    "Expected a conditional expression and instead saw an assignment"
  * Stackfilter fix: Don't remove modules/components from stack trace in the browser
  * Merge pull request [#1878](https://github.com/mochajs/mocha/issues/1878) from danielstjules/issue-1864
    Fix [#1864](https://github.com/mochajs/mocha/issues/1864): xunit missing output with --reporter-options output
  * Fix [#1864](https://github.com/mochajs/mocha/issues/1864): xunit missing output with --reporter-options output
  * Merge pull request [#1876](https://github.com/mochajs/mocha/issues/1876) from danielstjules/issue-1875
    Fix 1875: Markdown reporter exceeds maximum call stack size
  * Fix 1875: Markdown reporter exceeds maximum call stack size
  * IE<=8 no [].reduce, so use 'utils.reduce' instead

2.3.2 / 2015-09-08
==================

  * Release v2.3.2
  * remove lodash.create; closes [#1868](https://github.com/mochajs/mocha/issues/1868)

2.3.1 / 2015-09-07
==================

  * update package.json & component.json for v2.3.1
  * update HISTORY.md
  * fix package.json to use exact version of lodash; closes [#1867](https://github.com/mochajs/mocha/issues/1867)
  * Merge pull request [#1852](https://github.com/mochajs/mocha/issues/1852) from aaroncrows/fix/1812-bail-runs-before-hooks
    Fix: Bail flag causes before() hooks to be run even after a failure
  * Fix: Bail flag causes before() hooks to be run even after a failure

2.3.0 / 2015-08-31
==================

  * Release v2.3.0
  * update HISTORY.md for v2.3.0
  * rebuild mocha.js
  * added allowUncaught option ([#553](https://github.com/mochajs/mocha/issues/553))
    allows unhandled exceptions to propagate in the browser
    added tests for allowUncaught option
    global error handler prints to dom with allowUncaught
  * Allow --async-only to be satisfied by returning a promise
    This results in a slight change to the behavior of --async-only:
    instead of failing immediately, check to see if the test returned
    a promise (or otherwise failed) before complaining about not
    having a done callback.
  * upgrade eslint to 1.2.1 w/ config & Makefile fixes
  * Merge pull request [#1829](https://github.com/mochajs/mocha/issues/1829) from gigadude/gigadude-max-old-space-size
    Support --max-old-space-size node argument
  * Merge pull request [#1835](https://github.com/mochajs/mocha/issues/1835) from outsideris/issue-1811
    Upgrade Jade dependency to 1.11.0
  * upgrade jade to v1.11.0
    Jade syntax isn't broken in new version, but update some syntax
    for being more explicitly. fix [#1811](https://github.com/mochajs/mocha/issues/1811)
  * fix undefined `str` variable for html coverage
    Order for variables definition is wrong in 3f78f10ca,
    so, html coverage page print `<undefined></undefined>`
    because str is undefined in `jade.compile(str, { filename: file });`.
  * Support --max-old-space-size node argument
  * Merge pull request [#1802](https://github.com/mochajs/mocha/issues/1802) from ajaykodali/fix/1769-asynchronous-error-handling
    Fix for async hook error handling issue
  * * Fixed async hook error handling issue where an error in the hook was bailing sibling suites too
    * Added unit test cases for async hook error handling
    * Fixed minor issue in existing sync hook error test case
    * Moving code to fixtures dir to make the hook.err.js tests more readable
    * Trimming the hook error test cases by removing hooks not under test
    * Fix indentation
    * Rename var to afterAllHookCalled
  * Merge pull request [#1447](https://github.com/mochajs/mocha/issues/1447) from duncanbeevers/descriptive-before-after-each
    Decorate failed hook titles with test title
  * Scope loading behaviour instead of using early return
    Fails under babel_node node_modules/mocha/bin/_mocha
    Transformation error; return original code
    { [SyntaxError: node_modules/mocha/bin/_mocha: 'return' outside of function (392:2)]
    pos: 9902,
    loc: { line: 392, column: 2 },
    raisedAt: 9908,
    _babel: true,
    codeFrame: '  390 |   });\n  391 | \n> 392 |   return;\n      |   ^\n  393 | }\n  394 | \n  395 | // load' }
    based on advice from @oakfang
    Signed-off-by: Joshua Appelman <jappelman@xebia.com>
    Closes [#1787](https://github.com/mochajs/mocha/issues/1787)
  * Merge pull request [#1788](https://github.com/mochajs/mocha/issues/1788) from sunesimonsen/fix/html-runner
    Fix: html-runner crashing because of missing process.stdout shim
  * Fix: html-runner crashing because of missing process.stdout shim
    When running mocha in the browser you get a crash in the following code:
    if (isatty) {
    exports.window.width = process.stdout.getWindowSize
    ? process.stdout.getWindowSize(1)[0]
    : tty.getWindowSize()[1];
    }
    That is because we need to shim the process.stdout before requiring
    mocha from browser-entry.js, I fixed that by moving it to the top of the
    file.
  * Merge pull request [#1749](https://github.com/mochajs/mocha/issues/1749) from tinganho/maxiumCErr
    Maximum call stack issue for large test suite
  * Fixes maximum call stack error
  * Merge pull request [#1784](https://github.com/mochajs/mocha/issues/1784) from ndhoule/refactor/remove-browserify-todo
    Remove TODO from Browserify transition
  * Remove TODO from Browserify transition
  * Decorate failed hook titles with test title
    Fixes [#1230](https://github.com/mochajs/mocha/issues/1230)
  * Merge branch 'ndhoule-chore/browserify'
    Closes [#1727](https://github.com/mochajs/mocha/issues/1727)
  * Build using Browserify
    Signed-off-by: Joshua Appelman <jappelman@xebia.com>
    Closes [#1193](https://github.com/mochajs/mocha/issues/1193)
  * Merge pull request [#1753](https://github.com/mochajs/mocha/issues/1753) from ndhoule/refactor/remove-dunderproto
    Replace __proto__ references with inherits module
  * Merge pull request [#1781](https://github.com/mochajs/mocha/issues/1781) from glenjamin/test-hook-errors
    Rework hook error tests to actually assert
  * Rework hook error tests to actually assert
  * Move hook error test to integration in prep for rewrite
  * Merge branch 'master' into papandreou-feature/allowBooleanReporterOptions
  * Fix 1766: stackfilter should not ignore node_modules
    Closes [#1766](https://github.com/mochajs/mocha/issues/1766)
    Closes [#1767](https://github.com/mochajs/mocha/issues/1767)
    Signed-off-by: Joshua Appelman <jappelman@xebia.com>
  * Remove __proto__ parsing from browser build scripts
  * Replace __proto__ with lodash.create
  * Removes heading newline.
  * Merge pull request [#1752](https://github.com/mochajs/mocha/issues/1752) from gsilk/master
    Stop runner sending SIGINT to itself from within SIGINT handler
  * Merge pull request [#1761](https://github.com/mochajs/mocha/issues/1761) from chromakode/explicit-null-and-defined
    Explicitly check `null` and `undefined` values in exports.type
  * Merge pull request [#1774](https://github.com/mochajs/mocha/issues/1774) from adamgruber/master
    support escaped spaces in cli options
  * support escaped spaces in cli options
  * Fixes indentation.
  * Simplifies split regex, the filter already catches empty args.
  * Removes unneeded trim, the filter does the same.
  * Simplifies filter by truthy values.
  * add lint check to test-all target.  YES!
  * remove dupe in contributors list
  * lock down supports-color dependency
  * lint runner.js
  * Merge commit 'f652414ac05d20685903ed33a14349df96283f4f' into chore/linting
    * commit 'f652414ac05d20685903ed33a14349df96283f4f':
    Escape test/suite title for re in html reporter
    Conflicts:
    lib/reporters/html.js
  * Merge pull request [#1698](https://github.com/mochajs/mocha/issues/1698) from benvinegar/fix-1687-2
    Escape test/suite title for re in html reporter
  * Escape test/suite title for re in html reporter
  * Remove npm version from engines field
  * CI: Update npm when < 1.3.7
  * Linting: Compliance
  * Linting: Add linter
    Follows @boneskull's `make test` suggestion in
    https://github.com/mochajs/mocha/pull/1534#issuecomment-73151037
  * update contributors