### PR TITLE
Update "sinon" to version ~1.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chai": "^1.9.2",
     "eslint": "^1.10.3",
     "mocha": "~2.2.1",
-    "sinon": "~1.14.1",
+    "sinon": "~1.17.2",
     "sinon-chai": "~2.8.0"
   },
   "dependencies": {


### PR DESCRIPTION
2.0.0-pre / 2015-12-02
======================

  * 2.0.0 pre-release
  * Merge pull request [#934](https://github.com/cjohansen/Sinon.JS/issues/934) from jonnyreeves/feature/cjsify-utils
    CommonJSify sinon utils package
  * Merge pull request [#933](https://github.com/cjohansen/Sinon.JS/issues/933) from jonnyreeves/feature/cjsify-mock
    CommonJSify `sinon.mock`
  * Extract `util/fake_server_with_clock` into a CommonJS module
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
  * Extract `util/fake_server` into a CommonJS module.
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
    This module still depends on the `sinon` object as the tests are tightly coupled to `sinon.useFakeXMLHttpRequest` and friends; once the tests are migrated to CommonJS we should be able to rectify this.
  * Extract `util/fake_timers` into a CommonJS module.
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
  * Extract `util/fake_xml_http_request` into a CommonJS module.
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
    This module still relies on the sinon object as the tests are tightly coupled to `sinon.logError` (they stub it to prevent uncaught exceptions); we should be able to resolve this once the tests are CommonJSified.
    I have reservations on the way `useFakeXMLHttpnRequest` mutates `FakeXMLHttpRequest` however I feel this is best refactored post the CommonJS transition.
  * Extract `util/fake_xdomain_request` into a CommonJS module.
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
    I have reservations on the way `useFakeXDomainRequest` mutates `FakeXDomainRequest` however I feel this is best refactored post the CommonJS transition.
  * Extract `util/event` into a CommonJS module.
    This module no-longer mutates the `sinon` object; instead it exports an API which is then added to the `sinon` global by the `lib/sinon.js` entrypoint.
  * Extract `sinon.logError` into a CommonJS module.
    This is a tricky one; it remains exported on the `sinon` object as there are a number of tests tightly coupled to it.  Once the tests are migrated to CommonJS we should be able to import it directly and remove the export onto the sinon object.
  * Extract (most of) sinon.collection into a CommonJS module
    This module still needs to depend on the `sinon` object as the tests are tightly coupled to both `sinon.stub` and `sinon.mock`; once the tests have been migrated to CommonJS this module can be made stand-alone.
  * Extract `sinon.mock` into a CommonJS module.
    Extract, `sinon.expectation`, an inner module into its own CommonJS module (`mock-expectation`).  This is still exported on the `sinon` object to satisfy tests.
  * Import mock's dependencies are CommonJS modules.
  * Extract `createSpyCall` into a CommonJS module.
    Similar to `spy.js`, the tests have a hard dependency on `sinon.format` which can't be removed until the tests themselves are CommonJSify'd
  * Extract `sinon.assert` into a CommonJS module.
  * Merge pull request [#932](https://github.com/cjohansen/Sinon.JS/issues/932) from jonnyreeves/feature/cjsify-stub
    CommonJSify `sinon.stub`
  * Remove `walk` from sinon's public API.
  * Merge pull request [#931](https://github.com/cjohansen/Sinon.JS/issues/931) from jonnyreeves/patch-1
    Delete .jscsrc
  * Patch up linting errors
  * Remove `sinon` import from stub
    ... and we're done here! :D
  * Extract `sinon.behavior` into a CommonJS module
    Not part of the public API
  * Extract `sinon.walk` into a CommonJS module.
    No other references outside of stub, but according to the docs it's part of sinon's public API.
  * Export stub as a CommonJS module
    Move `createStubInstance` to be a member of `stub`; remove local references to `sinon.stub`
  * Import `wrapMethod` as a CommonJS module
    Had to defer a couple of stub-tests which tightly coupled stub.js to `sinon.wrapMethod`; should be able to re-instate these when the test-suite is converted to use commonJS
  * Import core dependencies as CommonJS modules
  * Delete .jscsrc
    Following on from [#909](https://github.com/cjohansen/Sinon.JS/issues/909), this file is now redundant.
  * Merge pull request [#930](https://github.com/cjohansen/Sinon.JS/issues/930) from fatso83/web-worker-support
    Ensure support for running inside a WebWorker
  * Ensure sinon can run in a  WebWorker
    Related to the fixes in [#908](https://github.com/cjohansen/Sinon.JS/issues/908).
    It turned out that although we support running Sinon inside
    a WebWorker, we do not actually test this in any of the tests.
    This test will be run by the test config of the packaged build.
    As PhantomJS 1.9.8 does not implement WorkerGlobalScope, the
    test if we are running in a WebWorker is a bit simplified, but
    it works for us.
  * Merge pull request [#920](https://github.com/cjohansen/Sinon.JS/issues/920) from fearphage/cjs-spy
    Commonjs-ified sinon.spy
  * Merge pull request [#927](https://github.com/cjohansen/Sinon.JS/issues/927) from azizpunjani/called-on-accepts-matcher
    Updated docs to reflect that calledOn accepts a matcher
  * Updated docs to reflect that calledOn accepts a matcher
  * simplified test and added a note
  * updated to require spy in its new cjs form
  * ./commonjs
  * expose sinon.spy and sinon.spyCall
  * converted spy to commonjs format
    * sinon/core.format is the last non-cjs piece
  * Merge pull request [#866](https://github.com/cjohansen/Sinon.JS/issues/866) from shaine/fix/callbackContextError
    Allow yieldsOn, callsArgOn on any defined context
  * moved sinon.format() to core
    * commonjs-ified sinon.format
  * Merge pull request [#918](https://github.com/cjohansen/Sinon.JS/issues/918) from fearphage/fix-spy-property-descriptors
    Fix interaction with spy getters/setters - fixes [#917](https://github.com/cjohansen/Sinon.JS/issues/917)
  * fixed spy tests
  * added missing test (pushes spy coverage to 100%)
  * added spy getter/setter tests
  * updated sinon.spy() to properly handle getters and setters
  * Merge pull request [#915](https://github.com/cjohansen/Sinon.JS/issues/915) from thefourtheye/patch-1
    Remove unnecessary error variable
  * Remove unnecessary error variable
  * Merge pull request [#913](https://github.com/cjohansen/Sinon.JS/issues/913) from fearphage/fix-stubbed-getter
    Prevent stubbed getter from being called during restore()
  * Prevent stubbed getter from being called during restore() - fixes [#897](https://github.com/cjohansen/Sinon.JS/issues/897)
  * Merge pull request [#894](https://github.com/cjohansen/Sinon.JS/issues/894) from JoshuaKGoldberg/patch-1
    Allow requestBody in FakeXDomainRequest, FakeXMLHttpRequest for GET requests
  * Allowed GET requests to have request bodies
    As per the spec, they should be allowed. This removes them from the
    blacklist (which now is just HEAD), and adds unit tests.
  * Merge pull request [#891](https://github.com/cjohansen/Sinon.JS/issues/891) from mroderick/use-immediate-exceptions
    Use immediate exceptions
  * Merge pull request [#909](https://github.com/cjohansen/Sinon.JS/issues/909) from mroderick/remove-jscs-from-devdependencies
    Remove JSCS from devDependencies
  * Remove JSCS from devDependencies
    We haven't used it for awhile, let's stop installing it
  * Merge pull request [#907](https://github.com/cjohansen/Sinon.JS/issues/907) from gitter-badger/gitter-badge
    Add a Gitter chat badge to README.md
  * Add Gitter badge
  * Merge pull request [#899](https://github.com/cjohansen/Sinon.JS/issues/899) from fearphage/simplify-match
    Replaced switch statement in favor of object lookup
  * Allow yieldsOn, callsArgOn, callsArgOnWith, yieldsToOn to use any
    context
  * Merge pull request [#901](https://github.com/cjohansen/Sinon.JS/issues/901) from mroderick/add-bithound-badges
    Add bithound badge to README.md
  * Add bithound badge to README.md
  * removed switch statement in favor of object lookup
  * Merge pull request [#889](https://github.com/cjohansen/Sinon.JS/issues/889) from jollytoad/issue-887-squashed
    Allow prototype-less comparisons
    Fixes [#887](https://github.com/cjohansen/Sinon.JS/issues/887)
  * Merge pull request [#886](https://github.com/cjohansen/Sinon.JS/issues/886) from johann-sonntagbauer/fix[#875](https://github.com/cjohansen/Sinon.JS/issues/875)
    Fix [#875](https://github.com/cjohansen/Sinon.JS/issues/875) Proper support UTF8 payloads
  * Merge pull request [#890](https://github.com/cjohansen/Sinon.JS/issues/890) from mroderick/import-docs
    New documentation site!

1.17.2 / 2015-10-21
===================

  * Use immediate exceptions
  * Merge pull request [#858](https://github.com/cjohansen/Sinon.JS/issues/858) from timwienk/bug-ie11-window-conditionals
    lib/sinon/util: Remove window conditionals from IE files.
  * lib/sinon/util: Remove window conditionals from IE files.
    The removed conditionals should not have any functional benefit, so in
    that sense it's safe to remove these. (As described in [#840](https://github.com/cjohansen/Sinon.JS/issues/840).)
    However, it appears that these conditionals have an unintended effect
    in IE 11 and Edge 12, where the functions defined within the
    conditionals actually stop working as expected. (See [#848](https://github.com/cjohansen/Sinon.JS/issues/848).)
    While it is true these IE utils are not necessary for the newer IEs,
    they are often still loaded as part of a generic test package.
    Additionally, to make the ci-tests work:
    - Renamed util/*_ie.js to util-ie/*.js.
    - Made sure IE utils are not included in node tests.
    They were included before, but didn't actually run because of the
    `if (typeof window !== 'undefined')` conditional. With the conditional
    gone, just don't include them.
    Closes [#840](https://github.com/cjohansen/Sinon.JS/issues/840).
    Fixes [#848](https://github.com/cjohansen/Sinon.JS/issues/848).
  * Add docs for sandbox and utils
  * Add documentation for matchers
  * Add docs for assertions
  * Add docs for JSON-P
  * Add docs for fake server
  * Add docs for fake timers
  * Add mock api descriptions
  * Add mocks introduction
  * Add stubs api
  * Update TODO
  * Use Object.prototype.hasOwnProperty in deepEqual to cope with cases where hasOwnProperty doesn't exist, ie. Object.create(null), or has been overridden on an object.
    With tests.
  * Add docs TODO to track outstanding tasks
  * Add stubs.md with introduction to stubs
  * Import docs
  * Fix [#875](https://github.com/cjohansen/Sinon.JS/issues/875) Proper support UTF8 payloads
    * introduced new dependency "text-encoding"
    * delegate encoding operations to TextEncoder/TextDecoder
    * added unit test to verify proper utf-8 encoding
  * Merge pull request [#884](https://github.com/cjohansen/Sinon.JS/issues/884) from fearphage/upgrade-eslint
    upgraded ESLint to 1.7.1 (latest and greatest)
  * finished eslint'ing
  * upgraded ESLint to 1.7.1 (latest and greatest)
    * fixed spacing to pass
  * Merge pull request [#879](https://github.com/cjohansen/Sinon.JS/issues/879) from fearphage/remove-duplicate-times-in-words
    Removed duplicate implementation of sinon.timesInWords
  * Merge pull request [#881](https://github.com/cjohansen/Sinon.JS/issues/881) from mroderick/travis-cache-node-modules
    Make travis cache node_modules to speed up builds
  * Merge pull request [#882](https://github.com/cjohansen/Sinon.JS/issues/882) from fearphage/remove-npm-bin
    Removed unneeded path resolution
  * Merge pull request [#883](https://github.com/cjohansen/Sinon.JS/issues/883) from mroderick/test-in-node-lts
    Run tests in node 4.2 LTS (Argon)
  * Run tests in node 4.2 LTS (Argon)
  * Merge pull request [#873](https://github.com/cjohansen/Sinon.JS/issues/873) from fearphage/commonjs-ify
    CommonJS-ified *some* of the things
  * removed unneeded path resolution
  * Let npm install handle buster again, now that we have caching of node_modules
  * Make travis cache node_modules to speed up builds