### PR TITLE
Update "sinon-chai" to version ~2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "^0.20.0",
     "mocha": "~2.2.1",
     "sinon": "~1.14.1",
-    "sinon-chai": "~2.7.0"
+    "sinon-chai": "~2.8.0"
   },
   "dependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
2.8.0 / 2015-06-07
==================

  * Version 2.8.0.
  * Run CI on io.js as well
  * Support Chai 3.x
    Fixes [#65](https://github.com/domenic/sinon-chai/issues/65). Also tests against all supported Chai versions.
  * Fix license metadata for new npm requirements
  * Dual-license under WTFPL and BSD-2-Clause