### PR TITLE
Update "gmsmith" to version ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^0.26.2",
     "glob": "^6.0.1",
     "gm": "^1.21.1",
-    "gmsmith": "^0.6.4",
+    "gmsmith": "^1.0.0",
     "image-size": "^0.4.0",
     "mkdirp": "^0.5.1",
     "optipng-bin": "~2.0.4",


### PR DESCRIPTION
1.0.0 / 2015-11-18
==================

  * Release 1.0.0
  * Upgraded to spritesmith-engine-test@4.0.0
  * Added support for exporting jpg
  * Documented support input variations
  * Updated test expectations
  * Completed support for vinyl
  * Removed legacy cb parameters
  * Updated documentation to use readable stream over binary string callback
  * Moved from binary string export to readable stream
  * Cleaned up extension vs format confusion
  * Added Canvas.defaultExtension
  * Added missing export
  * Fixed up bad path
  * Fixed up TODO
  * Added specVersion to Gmsmith
  * Added missing link for ImageMagick
  * Fixed up spacing for GraphicsMagick
  * Updated documentation and fixed up useImageMagick logic
  * Merge branch 'dev/spec.v2' into dev/v2.0a