### PR TITLE
Update "optipng-bin" to version ~3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gmsmith": "^0.6.4",
     "image-size": "^0.4.0",
     "mkdirp": "^0.5.1",
-    "optipng-bin": "~2.0.4",
+    "optipng-bin": "~3.0.4",
     "pngquant-bin": "~3.0.0",
     "q": "^2.0.3",
     "qlimit": "^0.1.1",


### PR DESCRIPTION
3.0.4 / 2015-12-09
==================

  * 3.0.4
  * ES2015ify readme
  * Test on `stable` instead of `iojs`
  * Remove unnecessary version check
    fix [#58](https://github.com/imagemin/optipng-bin/issues/58)
    fix [#45](https://github.com/imagemin/optipng-bin/issues/45)
  * Show more useful error message
  * Use XO
    https://github.com/sindresorhus/xo

3.0.3 / 2015-11-13
==================

  * 3.0.3
  * Change version tag to include v
    As discussed in imagemin/gifsicle-bin[#55](https://github.com/imagemin/optipng-bin/issues/55), some imagemin bin packages prepend their version
    tags with v and some don't. This PR changes the behavior of this package to prepend tags
    with`v`, as do the majority of packages. This reduces the probability that a wrong tag
    is published by mistake.
    Merging this PR means that the next tag must be prepended with a v!
    Pull Request URL:
    https://github.com/imagemin/optipng-bin/pull/63
  * Replace `fs.exists` with `path-exists`

3.0.2 / 2015-06-06
==================

  * 3.0.2
  * Fix URL

3.0.1 / 2015-06-06
==================

  * 3.0.1
  * Minor tweak

3.0.0 / 2015-06-06
==================

  * 3.0.0
  * minor package.json tweaks
  * Use `mocha` for testing
  * Export it directly
  * Tweaks
  * Bump `bin-wrapper` dependency
  * Update .travis.yml