### PR TITLE
Update "yargs" to version ^4.8.0-candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "promise-queue": "^2.2.3",
     "rimraf": "^2.4.1",
     "underscore": "^1.8.3",
-    "yargs": "^4.4.0"
+    "yargs": "^4.8.0-candidate"
   },
   "files": [
     "lib",


### PR DESCRIPTION
<pre>4.8.0-candidate / 2016-07-04
============================

  * docs: added documentation about commands not inheriting configurations ([#526](https://github.com/yargs/yargs/issues/526))
    * Added documentation about commands not inheriting configurations
    * Moved new text about context, add more details
    * Add anchors for referenced methods
  * feat(command): derive missing command string from module filename ([#527](https://github.com/yargs/yargs/issues/527))
  * fix: drop unused camelcase dependency fixes [#516](https://github.com/yargs/yargs/issues/516) ([#525](https://github.com/yargs/yargs/issues/525))
  * Merge pull request [#524](https://github.com/yargs/yargs/issues/524) from yargs/patch-1
    fix: keep both zh and add zh_CN until yargs@5.x
  * fix: keep both zh and zh_CN until yargs@5.x
  * feat: add .commandDir(dir) to API to apply all command modules from a relative directory ([#494](https://github.com/yargs/yargs/issues/494))
    * feat: add .commandDir() API using require-directory
    * support for nested subcommands with relative dir
    * allow command module to only define command and desc
    * test: add some for commandDir
    * docs: document the .commandDir() method
    * use const where possible based on @maxrimue's review
  * chore(package): update mocha to version 2.5.2
    https://greenkeeper.io/
  * fix: fake a tty in tests, so that we can use the new set-blocking ([#512](https://github.com/yargs/yargs/issues/512))
  * Rename zh.json to zh_CN.json
    This is for simplified Chinese so the correct locale should be zh_CN. For traditional Chinese it should be something like zh_HK or zh_TW.
  * chore(package): update which to version 1.2.9
    https://greenkeeper.io/
  * fix: link build badge to master branch ([#505](https://github.com/yargs/yargs/issues/505))
    link build badge to master branch
  * link build badge to master branch

4.7.0-pre / 2016-05-02
======================

  * chore: fix up corrupt changelog
  * chore(release): 4.7.0
  * chore: upgrade nyc and standard-version
  * chore(package): update nyc to version 6.4.1 ([#490](https://github.com/yargs/yargs/issues/490))
    https://greenkeeper.io/
  * feat(completion): allow to get completions for any string, not just process.argv ([#470](https://github.com/yargs/yargs/issues/470))
    * feat(completion): allow to get completions for any string, not just `process.argv`
    Add new method `.getCompletion(args, done)` which receives an array of strings
    representing a line to complete, and calls the `done` callback with the
    resulting completions.
    Update the completion tests to pass the arguments explicitly to yargs. We can't
    pass them by mocking `process.argv` now because `process.argv` is only checked
    on `index.js`, which is called before the tests can apply the mock.
    * Fix indentation
    * Fix indentation
    * docs(completion): document .getCompletion() method
  * fix(pkgConf): fix aliases issues in .pkgConf() ([#478](https://github.com/yargs/yargs/issues/478))
    Update .pkgConf() to use the new configObjects option from yargs-parser, this way the aliases issues are solved.
    Change wording of pkgConf() tests and description as it no longer works by setting defaults, and add some further tests.
  * feat(configuration): Allow to directly pass a configuration object to .config() ([#480](https://github.com/yargs/yargs/issues/480))
  * docs: Moving 'else' to the same line as closing curly brace in example code ([#483](https://github.com/yargs/yargs/issues/483))
  * chore: Update AppVeyor and Travis configuration for Node.js v6 ([#488](https://github.com/yargs/yargs/issues/488))
  * feat(validation): Add .skipValidation() method ([#471](https://github.com/yargs/yargs/issues/471))
  * docs(default): Document deprecated alias of default() ([#481](https://github.com/yargs/yargs/issues/481))
  * chore: overhauled travis configuration thanks @maxrimue ([#482](https://github.com/yargs/yargs/issues/482))

4.6.0-candidate / 2016-04-11
============================

  * chore(release): 4.6.0
  * feat: switch to standard-version for release management
  * feat: upgrade to version of yargs-parser that introduces some slick new features, great work @elas7. update cliui, replace win-spawn, replace badge. ([#475](https://github.com/yargs/yargs/issues/475))
  * docs(license): update license to reflect work undertaken since project was forked from optimist
  * fix(my brand!): I agree with @osher lightweight isn't a huge selling point of ours any longer, see [#468](https://github.com/yargs/yargs/issues/468)
  * docs: fix link in docs, add link to our new standard-changelog format ([#473](https://github.com/yargs/yargs/issues/473))</pre>