### PR TITLE
Update "yargs" to version ^5.0.0-candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "promise-queue": "^2.2.3",
     "rimraf": "^2.4.1",
     "underscore": "^1.8.3",
-    "yargs": "^4.4.0"
+    "yargs": "^5.0.0-candidate"
   },
   "files": [
     "lib",


### PR DESCRIPTION
<pre>5.0.0-candidate / 2016-08-14
============================

  * chore(release): 5.0.0
  * tests: remove osx from CI, until Travis fixes OSX servers
  * docs: added gitter badge ([#593](https://github.com/yargs/yargs/issues/593))
  * chore(package): update string-width to version 1.0.2 ([#591](https://github.com/yargs/yargs/issues/591))
    https://greenkeeper.io/
  * Merge pull request [#590](https://github.com/yargs/yargs/issues/590) from yargs/greenkeeper-nyc-8.1.0
    Update nyc to version 8.1.0 🚀
  * chore(package): update nyc to version 8.1.0
    https://greenkeeper.io/
  * perf: defer requiring most external libs until needed ([#584](https://github.com/yargs/yargs/issues/584))
    * perf: defer requiring most external libs until needed
    * perf: do not require string-width more than once
  * feat: adds recommendCommands() for command suggestions ([#580](https://github.com/yargs/yargs/issues/580))
    * feat: provide suggestions if unknown command is called
    * add y18n locale support for command recommendations
    * fix tests for command recommendations
    * make german translation more personal
    * update .recommendCommands() following @nexdrew's review
    * add more tests for .recommendCommands()
    * add didyoumean threshold
    * mention in readme no parameter is required for .recommendCommands()
    * fix silly mistake
    * feat: adds recommendCommands()
    * fix: implement @nexdrew's suggestion; sort commands so that we recommend longest first
  * chore(package): update lodash.assign to version 4.2.0 ([#587](https://github.com/yargs/yargs/issues/587))
    https://greenkeeper.io/
  * chore(package): update yargs-parser to version 3.2.0 ([#588](https://github.com/yargs/yargs/issues/588))
    https://greenkeeper.io/
  * feat: add coerce api ([#586](https://github.com/yargs/yargs/issues/586))
    * feat: add coerce api
    * support coercion of positional args in command
    * docs: add .coerce() method
  * feat: apply default builder to command() and apply fail() handlers globally ([#583](https://github.com/yargs/yargs/issues/583))
    BREAKING CHANGE: fail is now applied globally.
    BREAKING CHANGE: we now default to an empty builder function when command is executed with no builder.
  * feat: interpret demand() numbers as relative to executing command ([#582](https://github.com/yargs/yargs/issues/582))
  * feat: update yargs-parser to version 3.1.0 ([#581](https://github.com/yargs/yargs/issues/581))
    BREAKING CHANGE: yargs-parser now better handles negative integer values, at the cost of handling numeric option names, e.g., -1 hello
  * feat: apply .env() globally ([#553](https://github.com/yargs/yargs/issues/553))
  * fix: remove deprecated zh.json ([#578](https://github.com/yargs/yargs/issues/578))
  * fix(default): Remove undocumented alias of default() ([#469](https://github.com/yargs/yargs/issues/469))
    BREAKING CHANGE:
    removed undocumented `defaults` alias for `default`.
  * feat(command): builder function no longer needs to return the yargs instance ([#549](https://github.com/yargs/yargs/issues/549))
    BREAKING CHANG:
    changes the behavior of a builder function, so that the updated yargs object no longer needs to be returned.
  * feat: .help() API can now enable implicit help command ([#574](https://github.com/yargs/yargs/issues/574))
    BREAKING CHANGE:
    introduces a default `help` command which outputs help, as an alternative to a help flag.
  * Merge pull request [#575](https://github.com/yargs/yargs/issues/575) from yargs/greenkeeper-mocha-3.0.1
    mocha@3.0.1 breaks build 🚨
  * chore(package): update mocha to version 3.0.1
    https://greenkeeper.io/
  * Merge pull request [#572](https://github.com/yargs/yargs/issues/572) from yargs/greenkeeper-mocha-3.0.0
    Update mocha to version 3.0.0 🚀
  * chore(package): update mocha to version 3.0.0
    https://greenkeeper.io/
  * docs: 'yargs is here to help you example' to demand both command and argument under the same demand ([#567](https://github.com/yargs/yargs/issues/567))

4.8.1-candidate / 2016-07-16
============================

  * chore(release): 4.8.1
  * fix: pull in @nexdrew's fixes to yargs-parser ([#560](https://github.com/yargs/yargs/issues/560))
  * fix: positional arguments were not being handled appropriately by parse() ([#559](https://github.com/yargs/yargs/issues/559))
  * fix: add config lookup for .implies() ([#556](https://github.com/yargs/yargs/issues/556))
    * WIP: add config lookup for .implies()
    * further improvements for making implies() config aware
    * directly look up configuration via yargs object again
    * tune logic in validation.js to check for configuration
    * fix config lookup for .implies() + test
  * fix(commandDir): make dir relative to caller instead of require.main.filename ([#548](https://github.com/yargs/yargs/issues/548))
  * coveralls@2.11.10 breaks build 🚨 ([#551](https://github.com/yargs/yargs/issues/551))
    * chore(package): update coveralls to version 2.11.10
    https://greenkeeper.io/
    * chore(package): update coveralls to version 2.11.11
  * fix: cache pkg lookups by path to avoid returning the wrong one ([#552](https://github.com/yargs/yargs/issues/552))

4.8.0-candidate3 / 2016-07-09
=============================

  * chore(release): 4.8.0
  * fix: ignore invalid package.json during read-pkg-up ([#546](https://github.com/yargs/yargs/issues/546))
  * feat: builder is now optional for a command module ([#545](https://github.com/yargs/yargs/issues/545))
  * fix: lazy-load package.json and cache. get rid of pkg-conf dependency. ([#544](https://github.com/yargs/yargs/issues/544))

4.8.0-candidate2 / 2016-07-09
=============================

  * Merge pull request [#543](https://github.com/yargs/yargs/issues/543) from yargs/greenkeeper-nyc-7.0.0
    Update nyc to version 7.0.0 🚀
  * chore(package): update nyc to version 7.0.0
    https://greenkeeper.io/
  * fix: we now respect the order of _ when applying commands ([#537](https://github.com/yargs/yargs/issues/537))

4.8.0-candidate / 2016-07-04
============================

  * docs: added documentation about commands not inheriting configurations ([#526](https://github.com/yargs/yargs/issues/526))
    * Added documentation about commands not inheriting configurations
    * Moved new text about context, add more details
    * Add anchors for referenced methods
  * feat(command): derive missing command string from module filename ([#527](https://github.com/yargs/yargs/issues/527))
  * fix: drop unused camelcase dependency fixes [#516](https://github.com/yargs/yargs/issues/516) ([#525](https://github.com/yargs/yargs/issues/525))
  * Merge pull request [#524](https://github.com/yargs/yargs/issues/524) from yargs/patch-1
    fix: keep both zh and add zh_CN until yargs@5.x
  * fix: keep both zh and zh_CN until yargs@5.x
  * feat: add .commandDir(dir) to API to apply all command modules from a relative directory ([#494](https://github.com/yargs/yargs/issues/494))
    * feat: add .commandDir() API using require-directory
    * support for nested subcommands with relative dir
    * allow command module to only define command and desc
    * test: add some for commandDir
    * docs: document the .commandDir() method
    * use const where possible based on @maxrimue's review
  * chore(package): update mocha to version 2.5.2
    https://greenkeeper.io/
  * fix: fake a tty in tests, so that we can use the new set-blocking ([#512](https://github.com/yargs/yargs/issues/512))
  * Rename zh.json to zh_CN.json
    This is for simplified Chinese so the correct locale should be zh_CN. For traditional Chinese it should be something like zh_HK or zh_TW.
  * chore(package): update which to version 1.2.9
    https://greenkeeper.io/
  * fix: link build badge to master branch ([#505](https://github.com/yargs/yargs/issues/505))
    link build badge to master branch
  * link build badge to master branch

4.7.0-pre / 2016-05-02
======================

  * chore: fix up corrupt changelog
  * chore(release): 4.7.0
  * chore: upgrade nyc and standard-version
  * chore(package): update nyc to version 6.4.1 ([#490](https://github.com/yargs/yargs/issues/490))
    https://greenkeeper.io/
  * feat(completion): allow to get completions for any string, not just process.argv ([#470](https://github.com/yargs/yargs/issues/470))
    * feat(completion): allow to get completions for any string, not just `process.argv`
    Add new method `.getCompletion(args, done)` which receives an array of strings
    representing a line to complete, and calls the `done` callback with the
    resulting completions.
    Update the completion tests to pass the arguments explicitly to yargs. We can't
    pass them by mocking `process.argv` now because `process.argv` is only checked
    on `index.js`, which is called before the tests can apply the mock.
    * Fix indentation
    * Fix indentation
    * docs(completion): document .getCompletion() method
  * fix(pkgConf): fix aliases issues in .pkgConf() ([#478](https://github.com/yargs/yargs/issues/478))
    Update .pkgConf() to use the new configObjects option from yargs-parser, this way the aliases issues are solved.
    Change wording of pkgConf() tests and description as it no longer works by setting defaults, and add some further tests.
  * feat(configuration): Allow to directly pass a configuration object to .config() ([#480](https://github.com/yargs/yargs/issues/480))
  * docs: Moving 'else' to the same line as closing curly brace in example code ([#483](https://github.com/yargs/yargs/issues/483))
  * chore: Update AppVeyor and Travis configuration for Node.js v6 ([#488](https://github.com/yargs/yargs/issues/488))
  * feat(validation): Add .skipValidation() method ([#471](https://github.com/yargs/yargs/issues/471))
  * docs(default): Document deprecated alias of default() ([#481](https://github.com/yargs/yargs/issues/481))
  * chore: overhauled travis configuration thanks @maxrimue ([#482](https://github.com/yargs/yargs/issues/482))

4.6.0-candidate / 2016-04-11
============================

  * chore(release): 4.6.0
  * feat: switch to standard-version for release management
  * feat: upgrade to version of yargs-parser that introduces some slick new features, great work @elas7. update cliui, replace win-spawn, replace badge. ([#475](https://github.com/yargs/yargs/issues/475))
  * docs(license): update license to reflect work undertaken since project was forked from optimist
  * fix(my brand!): I agree with @osher lightweight isn't a huge selling point of ours any longer, see [#468](https://github.com/yargs/yargs/issues/468)
  * docs: fix link in docs, add link to our new standard-changelog format ([#473](https://github.com/yargs/yargs/issues/473))</pre>