### PR TITLE
Update "yargs" to version ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "promise-queue": "^2.2.3",
     "rimraf": "^2.4.1",
     "underscore": "^1.8.3",
-    "yargs": "^5.0.0-candidate"
+    "yargs": "^6.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
<pre>
6.0.0-alpha.1 / 2016-09-30
==========================

  * docs: fix cruft in changelog
  * chore(release): 6.0.0
  * chore: rename version to release
  * chore: upgrade yargs-parser ([#633](https://github.com/yargs/yargs/issues/633))
    * chore: upgrade yargs-parser
    BREAKING CHANGE: coerce is now applied as a final step after other parsing is complete
    * add documentation for breaking changes in yargs-parser@4
    * fix: a few small editing nits
    * fix: bump yargs-parser again
  * fix: drop lodash.assign ([#641](https://github.com/yargs/yargs/issues/641))
  * chore: add greenkeeper ignore rule for string-width, which no longer supports Node 0.10 ([#634](https://github.com/yargs/yargs/issues/634))
  * fix: for args that have skipValidation set to `true`, check if the parsed arg is `true` ([#619](https://github.com/yargs/yargs/issues/619))
    * For args that have skipValidation set to `true`, check if the parsed arg is `true`
    When an arg is defined, it will always exist in the parsed argv. Thus, validation would always be skipped, regardless of whether an arg that has `skipValidation` set to `true` is actually passed on the command line. This commit checks to see if the parsed argv value is actually set to true.
    * Added test for `skipValidation` fix
  * Merge pull request [#636](https://github.com/yargs/yargs/issues/636) from yargs/greenkeeper-standard-8.2.0
    standard@8.2.0 breaks build 🚨
  * Merge pull request [#639](https://github.com/yargs/yargs/issues/639) from yargs/greenkeeper-es6-promise-4.0.2
    Update es6-promise to version 4.0.2 🚀
  * chore(package): update es6-promise to version 4.0.2
    https://greenkeeper.io/
  * chore(package): update standard to version 8.2.0
    https://greenkeeper.io/
  * feat: make opts object optional for .option() ([#624](https://github.com/yargs/yargs/issues/624))
  * fix: upgrade standard, and fix appveyor config so that it works with newest standard ([#607](https://github.com/yargs/yargs/issues/607))
    * test: do both cmd and PowerShell fail
    * fix: simplify appveyor configuration
  * style: clean up indentation in options block ([#615](https://github.com/yargs/yargs/issues/615))
    The nested `if` blocks look like `else if`'s
    Signed-off-by: Will Soto <will.soto9@gmail.com>
  * perf: defer windowWidth() to improve perf for non-help usage ([#610](https://github.com/yargs/yargs/issues/610))
    * defer windowWidth() to improve perf for non-help usage
    * respond to @nexdrew's comments
    * add 2nd arg to maxWidth() per @nexdrew
  * ci: test with latest node 6 again, drop node 5 ([#602](https://github.com/yargs/yargs/issues/602))
    * ci: test with node 6 once 6.4.0 is patched
    * chore: drop node 5 (no LTS)
    * test: add optional inferred function name for node 6.5.0
  * docs: mention config file names must end in .json ([#604](https://github.com/yargs/yargs/issues/604))
  * fix: changed parsing of the command string to ignore extra spaces ([#600](https://github.com/yargs/yargs/issues/600))
  * test: fix tests when run without TTY ([#597](https://github.com/yargs/yargs/issues/597))
    * test: fix process mocking in case of exception
    Fix how the process/io mocking in `test/helpers/utils.js` handles
    synchronous uncaught exceptions by adding a `finally` handler
    resetting the mocked state.
    * test: skip tests which require the window size when run without TTY
    Skip two tests that would throw an exception when the test output
    is redirected to a non-TTY (e.g. `npm test | cat`).
    * test: show more debugging information when integration tests fail
    * test: maybe fix tests on AppVeyor machines
    * ci: temporarily set Node v6 version to v6.3.1
    See https://github.com/nodejs/node/issues/8138.
  * re-enable macOS builds</pre>